### PR TITLE
Fix build and a failing test

### DIFF
--- a/z3.go
+++ b/z3.go
@@ -12,7 +12,7 @@
 package z3
 
 // #cgo CFLAGS: -Ivendor/z3/src/api
-// #cgo LDFLAGS: ${SRCDIR}/libz3.a -lstdc++
+// #cgo LDFLAGS: ${SRCDIR}/libz3.a -lstdc++ -lm
 // #include <stdlib.h>
 // #include "go-z3.h"
 import "C"

--- a/z3_examples_test.go
+++ b/z3_examples_test.go
@@ -128,8 +128,8 @@ func ExampleFindModel2() {
 	y := ctx.Const(ctx.Symbol("y"), ctx.IntSort())
 
 	// Create a couple integers
-	v1 := ctx.Const(ctx.SymbolInt(1), ctx.IntSort())
-	v2 := ctx.Const(ctx.SymbolInt(2), ctx.IntSort())
+	v1 := ctx.Int(1, ctx.IntSort())
+	v2 := ctx.Int(2, ctx.IntSort())
 
 	// y + 1
 	y_plus_one := y.Add(v1)
@@ -182,10 +182,10 @@ func ExampleFindModel2() {
 
 	// Output:
 	// Solving part 1
-	// x = 0
-	// y = 1
+	// x = 3
+	// y = 3
 	//
 	// Solving part 2
-	// x = 0
-	// y = 1
+	// x = 3
+	// y = 4
 }


### PR DESCRIPTION
The latest version of z3 would fail to run the tests when built:

```
go test -v
# github.com/mitchellh/go-z3
/usr/bin/ld: ./libz3.a(hwf.o): undefined reference to symbol 'remainder@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
FAIL    github.com/mitchellh/go-z3 [build failed]
```
I have added a reference to the Math library with `-lm` to fix this problem.

When the tests built after applying the fix, there was a failing test:

```
=== RUN   ExampleFindModel2
--- FAIL: ExampleFindModel2 (0.01s)
got:
Solving part 1
x = 0
y = 1

Solving part 2
x = (- 1)
y = 0
want:
Solving part 1
x = 0
y = 1

Solving part 2
x = 0
y = 1
FAIL
```
Which I fixed to match the comment.
https://github.com/mitchellh/go-z3/blob/4cbedeba863fd231d38eb2d5fc42c368d597fa79/z3_examples_test.go#L137
Also with the additional constraint: 
https://github.com/mitchellh/go-z3/blob/4cbedeba863fd231d38eb2d5fc42c368d597fa79/z3_examples_test.go#L163

Giving a new output:
https://github.com/mitchellh/go-z3/blob/121f7c630954a054dc160c4cae8fd83cd7c2d323/z3_examples_test.go#L183-L190
