### PR TITLE
ldflags: link against libm

### DIFF
--- a/z3.go
+++ b/z3.go
@@ -12,7 +12,7 @@
 package z3
 
 // #cgo CFLAGS: -Ivendor/z3/src/api
-// #cgo LDFLAGS: ${SRCDIR}/libz3.a -lstdc++
+// #cgo LDFLAGS: ${SRCDIR}/libz3.a -lstdc++ -lm
 // #include <stdlib.h>
 // #include "go-z3.h"
 import "C"


### PR DESCRIPTION
otherwise I get:
```
# github.com/mitchellh/go-z3
/usr/bin/ld: ./libz3.a(hwf.o): undefined reference to symbol 'remainder@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib64/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:25: test] Error 2
```